### PR TITLE
Update tufte.css

### DIFF
--- a/tufte.css
+++ b/tufte.css
@@ -111,7 +111,7 @@ sub { top: 0.4rem; }
 h1 { font-style: italic;
       font-weight: 400;
       margin-top: 1.568rem;
-      margin-bottom: 0rem;
+      margin-bottom: 1.568rem;
       font-size: 2.5rem;
       line-height: 0.784; }
 
@@ -152,11 +152,11 @@ h6 {  font-style: italic;
       line-height: 1.63333333333; }
 
 subtitle { font-style: italic;
-           font-size: 2.1rem;
-           margin-bottom: 0;
-           margin-top: 1.8666666666667rem;
+           font-size: 1.8rem;
+           margin-bottom: 1.088888888889rem;
+           margin-top: 1.088888888889rem;
            display: block;
-           line-height: 0.93333333333; }
+           line-height: 1.088888888889; }
 
 table { width: 53%;
         text-align: right;

--- a/tufte.css
+++ b/tufte.css
@@ -55,7 +55,7 @@ body { width: 87.5%;
 article { position: relative; }
 
 p { font-size: 1.4rem;
-    line-height: 1.6;
+    line-height: 1.4;
     margin-top: 1.4rem;
     margin-bottom: 1.4rem;
     width: 55%;
@@ -92,7 +92,7 @@ sub { top: 0.4rem; }
                           margin-top: 0rem;
                           margin-bottom: 0rem;
                           font-size: 1.0rem;
-                          line-height: 2.24;
+                          line-height: 1.96;
                           vertical-align: baseline;
                           position: relative;
                           }
@@ -110,57 +110,57 @@ sub { top: 0.4rem; }
 
 h1 { font-style: italic;
       font-weight: 400;
-      margin-top: 1.792rem;
+      margin-top: 1.568rem;
       margin-bottom: 0rem;
       font-size: 2.5rem;
-      line-height: 0.896; }
+      line-height: 0.784; }
 
 h2 {  font-style: italic;
       font-weight: 400;
       font-size: 2.1rem;
-      margin-top: 2.1333333333333333rem;
+      margin-top: 1.86666666666667rem;
       margin-bottom: 0rem;
-      line-height: 1.0666666666667; }
+      line-height: 0.9333333333333; }
 
 h3 {  font-style: italic;
       font-weight: 400;
       font-size: 1.8rem;
-      margin-top: 2.488888888888rem;
+      margin-top: 2.177777777778rem;
       margin-bottom: 0;
-      line-height: 1.2444444444; }
+      line-height: 1.088888888889; }
 
 h4 {  font-style: italic;
       font-weight: 400;
       font-size: 1.6rem;
-      margin-top: 2.8rem;
+      margin-top: 2.45rem;
       margin-bottom: 0;
-      line-height: 1.4; }
+      line-height: 1.225; }
 
 h5 {  font-style: italic;
       font-weight: 400;
       font-size: 1.4rem;
-      margin-top: 3.2rem;
+      margin-top: 2.8rem;
       margin-bottom: 0rem;
-      line-height: 1.6;
+      line-height: 1.4;
       }
 
 h6 {  font-style: italic;
       font-weight: 400;
       font-size: 1.2rem;
-      margin-top: 3.733333333333333rem;
+      margin-top: 3.266666666667rem;
       margin-bottom: 0rem;
-      line-height: 1.8666666666667; }
+      line-height: 1.63333333333; }
 
 subtitle { font-style: italic;
            font-size: 2.1rem;
-           margin-bottom: 1.06666666667rem;
-           margin-top: 1.06666666667rem;
+           margin-bottom: 0;
+           margin-top: 1.8666666666667rem;
            display: block;
-           line-height: 1.06666666667; }
+           line-height: 0.93333333333; }
 
 table { width: 53%;
         text-align: right;
-        font-size: 1.6rem;
+        font-size: 1.4rem;
         line-height: 1.4;
         margin-top: 1.4rem;
         margin-bottom: 1.4rem;

--- a/tufte.css
+++ b/tufte.css
@@ -1,14 +1,51 @@
-@font-face { font-family: ETBembo;
-             src: url("ETBembo-RomanLF.ttf"); }
+@font-face { font-family: ETBrembo;
+             src: url("ETBrembo-RomanLF.ttf"); }
+html{
+    text-align: baseline;
+    font-size: 11px;
+
+  }
+  @media screen and (min-width: 800px){
+    html{
+      font-size: 12px;
+    }
+    }
+
+  @media screen and (min-width: 900px){
+    html{
+      font-size: 13px;
+    }
+    }
+  @media screen and (min-width: 1000px){
+    html{
+      font-size: 14px;
+    }
+    }
+  @media screen and (min-width: 1100px){
+    html{
+      font-size: 15px;
+    }
+    }
+  @media screen and (min-width: 1200px){
+    html{
+      font-size: 16px;
+    }
+    }
+  @media screen and (min-width: 1300px){
+    html{
+      font-size: 17px;
+    }
+    }
 
 body { width: 87.5%;
        margin-left: auto;
        margin-right: auto;
        padding-left: 12.5%;
-       font-family: ETBembo, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
+       font-family: ETBrembo, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
        padding-bottom: 400px;
        background-color: #fffff8;
-       color: #111; }
+       color: #111;
+       max-width: 1400px; }
 
 .sans { font-family: "Gill Sans", "Gill Sans MT", Calibri, sans-serif; }
 .code { font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
@@ -17,62 +54,116 @@ body { width: 87.5%;
 
 article { position: relative; }
 
-p { font-size: 1.6em;
+p { font-size: 1.4rem;
+    line-height: 1.6;
+    margin-top: 1.4rem;
+    margin-bottom: 1.4rem;
     width: 55%;
-    padding-right: 0px; }
+    padding-right: 0px;
+    vertical-align: baseline;
+     }
+@media screen and (max-width: 600px){
+    p{
+      width: 70%;
+    }
+    }     
+@media screen and (max-width: 400px){
+    p{
+      width: 90%;
+    }
+    }
 
 a { color: #222; }
 
 img { max-width: 100%; }
+sup, sub {
+   vertical-align: baseline;
+   position: relative;
+   top: -0.4rem;
+}
+sub { top: 0.4rem; }
 
 .fullwidth { max-width: 95%; } 
 
 .sidenote, .marginnote { float: right;
-                         clear: right;
-                         margin-right: -60%;
-                         width: 50%;
-                         font-size: 0.84em; }
+                          clear: right;
+                          margin-right: -60%;
+                          width: 50%;
+                          margin-top: 0rem;
+                          margin-bottom: 0rem;
+                          font-size: 1.0rem;
+                          line-height: 2.24;
+                          vertical-align: baseline;
+                          position: relative;
+                          }
+@media screen and (max-width: 600px){
+    .sidenote, .marginnote{
+      width: 25%;
+      margin-right: -40%;
+    }
+    }
+@media screen and (max-width: 400px){
+    .sidenote, .marginnote{
+      display:none;
+    }
+    }
 
 h1 { font-style: italic;
-     font-weight: 400;
-     margin-top: 13%;
-     margin-bottom: 0.2em;
-     font-size: 2.5em; }
+      font-weight: 400;
+      margin-top: 1.792rem;
+      margin-bottom: 0rem;
+      font-size: 2.5rem;
+      line-height: 0.896; }
 
-h2 { font-style: italic;
-     font-weight: 400;
-     font-size: 2.1em;
-     margin-top: 1.5em; }
+h2 {  font-style: italic;
+      font-weight: 400;
+      font-size: 2.1rem;
+      margin-top: 2.1333333333333333rem;
+      margin-bottom: 0rem;
+      line-height: 1.0666666666667; }
 
-h3 { font-style: italic;
-     font-weight: 400;
-     font-size: 1.8em;
-     margin-top: 1.5em; }
+h3 {  font-style: italic;
+      font-weight: 400;
+      font-size: 1.8rem;
+      margin-top: 2.488888888888rem;
+      margin-bottom: 0;
+      line-height: 1.2444444444; }
 
-h4 { font-style: italic;
-     font-weight: 400;
-     font-size: 1.6em;
-     margin-bottom: 1.2em; }
+h4 {  font-style: italic;
+      font-weight: 400;
+      font-size: 1.6rem;
+      margin-top: 2.8rem;
+      margin-bottom: 0;
+      line-height: 1.4; }
 
-h5 { font-style: italic;
-     font-weight: 400;
-     font-size: 1.4em;
-     margin-bottom: 1em; }
+h5 {  font-style: italic;
+      font-weight: 400;
+      font-size: 1.4rem;
+      margin-top: 3.2rem;
+      margin-bottom: 0rem;
+      line-height: 1.6;
+      }
 
-h6 { font-style: italic;
-     font-weight: 400;
-     font-size: 1.2em;
-     margin-top: 1.5em;
-     margin-bottom: 1em; }
+h6 {  font-style: italic;
+      font-weight: 400;
+      font-size: 1.2rem;
+      margin-top: 3.733333333333333rem;
+      margin-bottom: 0rem;
+      line-height: 1.8666666666667; }
 
 subtitle { font-style: italic;
-           font-size: 2.1em;
-           margin-bottom: 0.2em;
-           display: block; }
+           font-size: 2.1rem;
+           margin-bottom: 1.06666666667rem;
+           margin-top: 1.06666666667rem;
+           display: block;
+           line-height: 1.06666666667; }
 
 table { width: 53%;
         text-align: right;
-        font-size: 1.6em;
+        font-size: 1.6rem;
+        line-height: 1.4;
+        margin-top: 1.4rem;
+        margin-bottom: 1.4rem;
         margin-left: 1%;
         margin-right: 1%;
         border-top: 2px solid #333333;
@@ -90,12 +181,13 @@ thead th { border-bottom: 1px solid #333333;
 
 a.url { text-decoration: none;
         word-break: break-all;
-        font-size: large;
         font-family: "Lucida Console", "Lucida Sans Typewriter", Monaco, "Bitstream Vera Sans Mono", monospace; }
 
-sup.sidenote-number { font-size: medium; }
 
-.sidenote sup.sidenote-number { font-size: small; }
+
+sup.sidenote-number { 
+      font-size: 0.9rem;
+      color: #f00000; }
 
 span.newthought { font-variant: small-caps; }
 
@@ -103,12 +195,12 @@ span.newthought { font-variant: small-caps; }
 .latex sub, .latex sup { text-transform: uppercase; }
 
 .latex sub { vertical-align: -0.5ex;
-             margin-left: -0.1667em;
-             margin-right: -0.125em; }
+             margin-left: -0.1667rem;
+             margin-right: -0.125rem; }
 
-.latex, .latex sub { font-size: 1em; }
+.latex, .latex sub { font-size: 1rem; }
 
-.latex sup { font-size: 0.85em;
-             vertical-align: 0.15em;
-             margin-left: -0.36em;
-             margin-right: -0.15em; }
+.latex sup { font-size: 0.85rem;
+             vertical-align: 0.15rem;
+             margin-left: -0.36rem;
+             margin-right: -0.15rem; }

--- a/tufte.css
+++ b/tufte.css
@@ -1,5 +1,5 @@
-@font-face { font-family: ETBrembo;
-             src: url("ETBrembo-RomanLF.ttf"); }
+@font-face { font-family: ETBembo;
+             src: url("ETBembo-RomanLF.ttf"); }
 html{
     text-align: baseline;
     font-size: 11px;
@@ -41,7 +41,7 @@ body { width: 87.5%;
        margin-left: auto;
        margin-right: auto;
        padding-left: 12.5%;
-       font-family: ETBrembo, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
+       font-family: ETBembo, Palatino, "Palatino Linotype", "Palatino LT STD", "Book Antiqua", Georgia, serif;
        padding-bottom: 400px;
        background-color: #fffff8;
        color: #111;


### PR DESCRIPTION
Changed font sizing to rems, and added media queries so that fonts scale as browser is resized in width. Also added top and bottom margins and rationalized line-heights so that sidenotes and marginnotes align to the same baseline as the main body copy.  For widths < 400px, sidenotes and marginnotes are not displayed at all.
